### PR TITLE
Chapter 04 fixes

### DIFF
--- a/chapter-04/docker-compose.yaml
+++ b/chapter-04/docker-compose.yaml
@@ -85,7 +85,7 @@ services:
       - AWS_REGION=us-east-1
     entrypoint: |
       /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc rm -r --force minio/warehouse;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;

--- a/chapter-04/lakehouse-preparer.sh
+++ b/chapter-04/lakehouse-preparer.sh
@@ -3,23 +3,23 @@
 set -e
 
 echo "Running notebook to create Iceberg tables..."
-docker compose exec spark-iceberg jupyter execute /home/iceberg/notebooks/create_iceberg_tables.ipynb
+docker-compose exec spark-iceberg jupyter execute /home/iceberg/notebooks/create_iceberg_tables.ipynb
 
 echo "Loading data from Postgres to Iceberg..."
-docker compose exec spark-iceberg /opt/spark/bin/spark-submit \
+docker-compose exec spark-iceberg /opt/spark/bin/spark-submit \
   --jars /home/iceberg/pyspark/jars/postgresql-42.7.6.jar \
   /home/iceberg/pyspark/scripts/postgres_loader.py
 
 echo "Loading data from MinIO to Iceberg..."
-docker compose exec spark-iceberg /opt/spark/bin/spark-submit \
+docker-compose exec spark-iceberg /opt/spark/bin/spark-submit \
   --jars /home/iceberg/pyspark/jars/hadoop-aws-3.3.4.jar,/home/iceberg/pyspark/jars/aws-java-sdk-bundle-1.11.1026.jar \
   /home/iceberg/pyspark/scripts/minio_loader.py
 
 echo "Transforming bronze to silver tables..."
-docker compose exec spark-iceberg /opt/spark/bin/spark-submit \
+docker-compose exec spark-iceberg /opt/spark/bin/spark-submit \
   /home/iceberg/pyspark/scripts/bronze_to_silver_transformer.py
 
 # echo "Creating gold layer tables in Trino..."
-docker compose exec trino trino --server localhost:8080 --file /opt/trino/iceberg-schema-gold.sql
+docker-compose exec trino trino --server localhost:8080 --file /opt/trino/iceberg-schema-gold.sql
 
 echo "Lakehouse preparation pipeline completed."

--- a/chapter-04/superset/Dockerfile
+++ b/chapter-04/superset/Dockerfile
@@ -2,7 +2,14 @@ FROM apache/superset:latest
 
 USER root
 
-# Install Trino SQLAlchemy driver
-RUN pip install 'trino[sqlalchemy]'
+# Install Trino SQLAlchemy driver and all dependencies
+RUN pip install trino[sqlalchemy] lz4 zstandard orjson tzlocal
+
+# Copy all packages to virtual environment
+RUN cp -r /usr/local/lib/python3.10/site-packages/trino* /app/.venv/lib/python3.10/site-packages/ && \
+    cp -r /usr/local/lib/python3.10/site-packages/lz4* /app/.venv/lib/python3.10/site-packages/ && \
+    cp -r /usr/local/lib/python3.10/site-packages/zstandard* /app/.venv/lib/python3.10/site-packages/ && \
+    cp -r /usr/local/lib/python3.10/site-packages/orjson* /app/.venv/lib/python3.10/site-packages/ && \
+    cp -r /usr/local/lib/python3.10/site-packages/tzlocal* /app/.venv/lib/python3.10/site-packages/
 
 USER superset


### PR DESCRIPTION
This PR
- Fixes the minio setup command
- Fixes the lakehouse-preparer script to use docker-compose instead of docker compose
- Adds in dependencies so that Trino driver is installed in superset

The aws-java-sdk-bundle-1.11.1026.jar is also required in the spark/jars folder