### PR TITLE
Updating the Dockerfile with correct URL for downloading Spark

### DIFF
--- a/chapter-02/spark/Dockerfile
+++ b/chapter-02/spark/Dockerfile
@@ -47,10 +47,9 @@ ENV SPARK_MAJOR_VERSION=3.5
 ENV ICEBERG_VERSION=1.9.0
 
 # Download spark
-RUN mkdir -p ${SPARK_HOME} \
- && curl https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
- && tar xvzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
- && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
+RUN mkdir -p ${SPARK_HOME} && \
+    curl -fsSL -L https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz | \
+    tar xz -C ${SPARK_HOME} --strip-components=1
 
 # Download iceberg spark runtime
 RUN curl https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-${SPARK_MAJOR_VERSION}_2.12/${ICEBERG_VERSION}/iceberg-spark-runtime-${SPARK_MAJOR_VERSION}_2.12-${ICEBERG_VERSION}.jar -Lo /opt/spark/jars/iceberg-spark-runtime-${SPARK_MAJOR_VERSION}_2.12-${ICEBERG_VERSION}.jar


### PR DESCRIPTION
- Replace unreliable dlcdn.apache.org with archive.apache.org
- Add curl flags (-fsSL -L) for better error handling
- Pipe download directly to tar for efficiency
- Fixes docker build failure: 'gzip: stdin: not in gzip format'"